### PR TITLE
Fix report section retrieval on link click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/app.js
+++ b/app.js
@@ -1132,7 +1132,7 @@ class EventHandlers {
     
     static handleReportLinkClick(e) {
         e.preventDefault();
-        const section = e.target.dataset.section;
+        const section = e.currentTarget.dataset.section;
         if (section) {
             ModalManager.openModal(section);
         }


### PR DESCRIPTION
## Summary
- Correct report link handler to read section from the element receiving the click
- Ignore node_modules directory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a796cea0108321b6f780ef08164c8f