### PR TITLE
Ensure print area visible when printing

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,3 +143,9 @@ footer {
     color: var(--color-text-muted);
     font-size: 0.9rem;
 }
+
+@media print {
+    #print-area {
+        display: block;
+    }
+}

--- a/yes.html
+++ b/yes.html
@@ -469,7 +469,7 @@
         </div>
     </div>
 
-    <!-- Print Area (hidden on screen, shown on print) -->
+    <!-- Print Area (hidden on screen, becomes visible when printing) -->
     <div id="print-area" class="hidden"></div>
 
     <!-- Modal Overlay -->


### PR DESCRIPTION
## Summary
- Display `#print-area` during printing with a new print media query.
- Update inline comment in `yes.html` to clarify print-only visibility of the print area.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a797c09b3083219d07aab9fee55c32