### PR TITLE
Fix report link click targeting for nested elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -1132,7 +1132,7 @@ class EventHandlers {
     
     static handleReportLinkClick(e) {
         e.preventDefault();
-        const section = e.target.dataset.section;
+        const section = e.currentTarget.dataset.section;
         if (section) {
             ModalManager.openModal(section);
         }


### PR DESCRIPTION
## Summary
- use `currentTarget` in report link click handler so clicking anywhere inside the link opens the correct modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a797c17ae48321a9662b983aed70dc