### PR TITLE
Avoid initializing app during tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1397,11 +1397,13 @@ window.addEventListener('unhandledrejection', (event) => {
     console.error('Unhandled promise rejection:', event.reason);
 });
 
-// Initialize app when DOM is ready
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => App.init());
-} else {
-    App.init();
+// Initialize app when DOM is ready (skip during tests)
+if (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => App.init());
+    } else {
+        App.init();
+    }
 }
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Summary
- guard application initialization so it doesn't run when NODE_ENV is set to test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7d71ad49083218e4122be608b8f1b