### PR TITLE
Enable dynamic report loading via Netlify function

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,11 +333,11 @@
                         <p class="text-gray-600">afox@autoreportserv.co</p>
                         <p class="text-gray-600">303-908-9815</p>
                     </div>
-                    <div>
+                    <div id="header-vehicle-info">
                         <h2 class="text-sm uppercase tracking-wide text-gray-500 font-semibold">Vehicle</h2>
-                        <p class="text-gray-800 font-bold">2022 Honda OK V EX</p>
-                        <p class="text-gray-600">VIN: WEIOTTOCSME12SASG</p>
-                        <p class="text-gray-600">Inspection: August 21, 2025</p>
+                        <p id="header-vehicle-model" class="text-gray-800 font-bold">Loading...</p>
+                        <p id="header-vehicle-vin" class="text-gray-600">Loading...</p>
+                        <p id="header-vehicle-date" class="text-gray-600">Loading...</p>
                     </div>
                 </div>
             </section>

--- a/netlify/functions/get-report.js
+++ b/netlify/functions/get-report.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+exports.handler = async function(event) {
+    const { vin } = event.queryStringParameters || {};
+
+    if (!vin) {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({ error: 'VIN parameter is required' })
+        };
+    }
+
+    try {
+        const sanitizedVin = vin.replace(/[^a-zA-Z0-9_-]/g, '');
+        const reportPath = path.join(__dirname, 'reports', `${sanitizedVin}.js`);
+        const reportData = require(reportPath);
+        return {
+            statusCode: 200,
+            body: JSON.stringify(reportData)
+        };
+    } catch (err) {
+        return {
+            statusCode: 404,
+            body: JSON.stringify({ error: 'Report not found' })
+        };
+    }
+};

--- a/netlify/functions/reports/vin123.js
+++ b/netlify/functions/reports/vin123.js
@@ -1,4 +1,4 @@
-const reportData = {
+module.exports = {
     vehicleInfo: {
         make: "Honda",
         model: "OK V EX",
@@ -11,11 +11,4 @@ const reportData = {
         engine: "1.5L Turbocharged I4",
         transmission: "CVT"
     }
-};
-
-exports.handler = async () => {
-    return {
-        statusCode: 200,
-        body: JSON.stringify(reportData)
-    };
 };


### PR DESCRIPTION
## Summary
- Add `get-report` serverless function to fetch vehicle reports by VIN.
- Convert report files into simple data modules and use them through the new API.
- Update client to load report data on page load and populate header and summary dynamically.
- Adjust printable and email outputs to derive vehicle info and statistics from loaded report.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7d8ebd630832191e54f8395686047