### PR TITLE
Add Gemini explanations for report issues

### DIFF
--- a/netlify/functions/get-explanation.js
+++ b/netlify/functions/get-explanation.js
@@ -1,0 +1,54 @@
+// Netlify function for explaining vehicle issues using Google Gemini
+const fetch = require('node-fetch');
+
+exports.handler = async function(event) {
+    if (event.httpMethod !== 'POST') {
+        return {
+            statusCode: 405,
+            body: JSON.stringify({ error: 'Method Not Allowed' })
+        };
+    }
+
+    try {
+        const { part } = JSON.parse(event.body || '{}');
+        const apiKey = process.env.GEMINI_API_KEY;
+
+        if (!apiKey) {
+            throw new Error('API key is not configured.');
+        }
+
+        const prompt = `Explain in simple terms what the automotive part "${part}" does, why it is important, and the risks of not addressing issues with it. Keep the explanation brief.`;
+
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                contents: [
+                    {
+                        parts: [{ text: prompt }]
+                    }
+                ]
+            })
+        });
+
+        if (!response.ok) {
+            const errData = await response.json().catch(() => ({}));
+            console.error('Gemini API Error:', errData);
+            throw new Error('The AI service returned an error.');
+        }
+
+        const data = await response.json();
+        const explanation = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+
+        return {
+            statusCode: 200,
+            body: JSON.stringify({ explanation: explanation.trim() })
+        };
+    } catch (error) {
+        console.error('Error in serverless function:', error);
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: "Sorry, we couldn't get an explanation at this time." })
+        };
+    }
+};

--- a/tests/appLogic.test.js
+++ b/tests/appLogic.test.js
@@ -114,6 +114,38 @@ describe('ApiService.fetchWithRetry', () => {
   });
 });
 
+describe('ApiService.explainIssue', () => {
+  beforeEach(() => {
+    jest.spyOn(LoadingIndicator, 'show').mockImplementation(() => {});
+    jest.spyOn(LoadingIndicator, 'hide').mockImplementation(() => {});
+    jest.spyOn(ErrorHandler, 'handleApiError').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns explanation on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ explanation: 'Brake pads slow the car.' })
+    });
+
+    const result = await ApiService.explainIssue('Brake pad');
+    expect(result).toBe('Brake pads slow the car.');
+    expect(fetch).toHaveBeenCalled();
+    expect(LoadingIndicator.show).toHaveBeenCalled();
+    expect(LoadingIndicator.hide).toHaveBeenCalled();
+  });
+
+  test('handles fetch error and returns fallback', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    const result = await ApiService.explainIssue('Brake pad');
+    expect(ErrorHandler.handleApiError).toHaveBeenCalled();
+    expect(result).toBe('Explanation not available at this time.');
+  });
+});
+
 describe('ChatManager', () => {
   test('reports missing container', async () => {
     const spy = jest.spyOn(ErrorHandler, 'showError').mockImplementation(() => {});

--- a/tests/eventHandlers.test.js
+++ b/tests/eventHandlers.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-const { EventHandlers } = require('../app');
+const { EventHandlers, ApiService } = require('../app');
 
 describe('EventHandlers.debounce', () => {
   beforeEach(() => {
@@ -31,5 +31,30 @@ describe('EventHandlers.debounce', () => {
     debounced();
     jest.advanceTimersByTime(300);
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('EventHandlers.handleExplainClick', () => {
+  test('fetches explanation and displays it', async () => {
+    document.body.innerHTML = `<button class="explain-btn" data-part="Brake pad">Explain</button><div class="explanation hidden"></div>`;
+    const btn = document.querySelector('.explain-btn');
+    const explanationDiv = document.querySelector('.explanation');
+    jest.spyOn(ApiService, 'explainIssue').mockResolvedValue('Brake pads slow the car.');
+
+    await EventHandlers.handleExplainClick({ target: btn });
+
+    expect(ApiService.explainIssue).toHaveBeenCalledWith('Brake pad');
+    expect(explanationDiv.textContent).toBe('Brake pads slow the car.');
+    expect(explanationDiv.classList.contains('hidden')).toBe(false);
+
+    ApiService.explainIssue.mockRestore();
+  });
+
+  test('ignores clicks without button', async () => {
+    document.body.innerHTML = `<div class="explanation hidden"></div>`;
+    const spy = jest.spyOn(ApiService, 'explainIssue').mockResolvedValue('');
+    await EventHandlers.handleExplainClick({ target: document.body });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- show an "Explain It" button on attention/immediate checklist items
- fetch plain-language explanations from Gemini via new serverless function
- test the explanation API and event handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa2121665c8321be00930737a12ab0